### PR TITLE
Show 'expectation' resultType results as 100% or 0%

### DIFF
--- a/frontend/src/screens/dataset/components/ObjectiveHitRate.jsx
+++ b/frontend/src/screens/dataset/components/ObjectiveHitRate.jsx
@@ -27,7 +27,7 @@ function ObjectiveHitRate({ stats }) {
     },
     dataset: {
       source: validationsDataset(),
-      dimensions: ['timestamp', 'Percentage'],
+      dimensions: ['timestamp', 'Pass Rate'],
     },
     xAxis: {
       type: 'time',
@@ -65,11 +65,11 @@ function ObjectiveHitRate({ stats }) {
     },
     series: [
       {
-        name: 'Percentage',
+        name: 'Pass Rate',
         type: 'line',
         encode: {
           x: 'timestamp',
-          y: 'Percentage',
+          y: 'Pass Rate',
         },
         color: '#333',
         showSymbol: true,
@@ -103,7 +103,7 @@ function ObjectiveHitRate({ stats }) {
           value={thirtyOneDayAvg ? thirtyOneDayAvg.toFixed(0) : '-'}
         />
         <div className="ant-statistic">
-          <div className="ant-statistic-title">Hit rate over the last month</div>
+          <div className="ant-statistic-title">Pass rate over the last month</div>
           <ReactECharts style={{ height: 43, width: 300 }} option={options} />
         </div>
       </Space>


### PR DESCRIPTION
# Description
**Update 1**
Expectations have different result types. E.g. `column_map_expectation`, `column_aggregate_expectation`, and `expectation`.

Expectations with a result type of `expectation` are typically table level validations and either produce a numerical result or a string result.

In this PR, we want to update the ExpectationHistory component to display `expectation` result types of type string with `success=true` as `100%` and `success=false` as `0%`.

**Before**
<img width="774" alt="Screenshot 2022-08-21 at 19 53 11" src="https://user-images.githubusercontent.com/20202312/185806553-4698fa96-fbab-41e3-97c2-f6b45a1a7d6c.png">


**After**
<img width="810" alt="Screenshot 2022-08-21 at 19 51 41" src="https://user-images.githubusercontent.com/20202312/185806507-dec91c69-1fee-4877-927d-c4d19d831fb5.png">


**Update 2**
Similarly to the above, only expectations with a result type of `column_map_expectation` support the property `objective`. In this PR, we want to remove `objective` from the `ExpectationHistory` component tooltip when result type is `column_aggregate_expectation`, and `expectation`.

**Before**
<img width="791" alt="Screenshot 2022-08-21 at 19 53 35" src="https://user-images.githubusercontent.com/20202312/185806558-dbe3245c-6b1b-4280-9e2f-ee169ba82b2b.png">


**After**
<img width="797" alt="Screenshot 2022-08-21 at 21 38 55" src="https://user-images.githubusercontent.com/20202312/185810137-cab1d193-faf3-4acd-bafe-6039b74467af.png">

<img width="827" alt="Screenshot 2022-08-21 at 21 39 07" src="https://user-images.githubusercontent.com/20202312/185810252-761fecf7-fb15-4535-984c-759e068b893f.png">




Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] All GitHub workflows have passed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules