### PR TITLE
✨ Show "COLUMN" on Dataset "Expectations" tab

### DIFF
--- a/frontend/src/screens/dataset/index.jsx
+++ b/frontend/src/screens/dataset/index.jsx
@@ -93,7 +93,6 @@ const Dataset = withRouter(() => {
   const [activeTab, setActiveTab] = useState(tab || EXPECTATIONS);
 
   const { datasetSchema, datasetName, isVirtual } = splitDatasetResource(dataset);
-  const ignoredProps = ['catch_exceptions', 'include_config', 'result_format'];
 
   useEffect(() => {
     if (!tab) {

--- a/frontend/src/screens/dataset/index.jsx
+++ b/frontend/src/screens/dataset/index.jsx
@@ -380,7 +380,17 @@ const Dataset = withRouter(() => {
 
   const columns = [
     {
-      title: 'NAME',
+      title: 'COLUMN',
+      dataIndex: 'column',
+      width: 200,
+      render: (text) => (
+        <div style={{ wordWrap: 'break-word', wordBreak: 'break-word' }}>
+          {text}
+        </div>
+      ),
+    },
+    {
+      title: 'EXPECTATION',
       dataIndex: 'expectation_type',
     },
     {
@@ -499,32 +509,17 @@ const Dataset = withRouter(() => {
     create_date: moment(suggestion.create_date).local().fromNow(),
   }));
 
-  const expectationsList = expectations.map((item) => {
-    const args = Object.keys(item.kwargs).map((property) => {
-      const kwargValue = item.kwargs[property];
-      if (!ignoredProps.includes(property) && (kwargValue !== undefined || kwargValue !== null)) {
-        return (
-          <div key={property}>
-            {property}
-            :
-            {' '}
-            {JSON.stringify(kwargValue)}
-          </div>
-        );
-      }
-      return null;
-    });
-    return {
-      key: item.key,
-      expectation_type: item.expectation_type,
-      validations: item.validations,
-      documentation: item.documentation,
-      arguments: args,
-      resultType: item.result_type,
-      create_date: moment(item.create_date).local().fromNow(),
-      modified_date: moment(item.modified_date).local().fromNow(),
-    };
-  });
+  const expectationsList = expectations.map((item) => ({
+    key: item.key,
+    expectation_type: item.expectation_type,
+    validations: item.validations,
+    documentation: item.documentation,
+    column: item.kwargs?.column ? item.kwargs.column : '',
+    kwargs: item.kwargs,
+    resultType: item.result_type,
+    create_date: moment(item.create_date).local().fromNow(),
+    modified_date: moment(item.modified_date).local().fromNow(),
+  }));
 
   const analyzeDataset = () => new Promise((resolve) => {
     postRunnerValidateDataset(datasetId).then(() => {


### PR DESCRIPTION
# Description
When viewing the Expectations tab on a dataset, I want to be able to easily see the name of the column it is being applied to. In the case where it's a table level expectation and there is no column, leave it blank.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] All GitHub workflows have passed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules