### PR TITLE
Propose a one-liner in the docs to generate the SECRET_KEY

### DIFF
--- a/docs/docs/configuration/how-to-update-SECRET_KEY.md
+++ b/docs/docs/configuration/how-to-update-SECRET_KEY.md
@@ -5,11 +5,9 @@ sidebar_position: 3
 # How to Update SECRET_KEY
 
 Run the following snippet to create a Fernet Key and set `SECRET_KEY` to it.
-```python
-from cryptography.fernet import Fernet
 
-fernet_key = Fernet.generate_key()
-print(fernet_key.decode())  # your fernet_key, keep it in a secure place!
+```sh
+poetry run python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ```
 
 :::note Note


### PR DESCRIPTION
# Description

This morning when I set up my local environment for Swiple, I had to generate a new `SECRET_KEY`. The proposed method in the docs work, but it requires to open a Python shell (with `cryptography` installed) and copy-paste the commands.

For convenience, I thought it could be nice to propose a one-liner that the user could just copy-paste and run to get its key. 

Besides, the command suggests to use the Poetry shell, so if the user correctly followed the installation path, `cryptography` should be available in its environment.
 
## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update

# Checklist:

- [X] I have performed a self-review of my own code
- [x] All GitHub workflows have passed
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules