### PR TITLE
Add field type to improve encrypted secrets handling

### DIFF
--- a/backend/app/models/datasource.py
+++ b/backend/app/models/datasource.py
@@ -4,7 +4,7 @@ from pydantic import Field, Extra
 from typing import Optional, Literal
 from app.settings import settings
 from app.db.client import client
-from app.models.types import EncryptedStr, EncryptedStrGetterSetterMixin
+from app.models.types import EncryptedStr, EncryptedStrSetterMixin
 from opensearchpy import NotFoundError
 
 
@@ -19,7 +19,7 @@ TRINO = "Trino"
 Engines = Literal[ATHENA, POSTGRESQL, MYSQL, REDSHIFT, SNOWFLAKE, TRINO]
 
 
-class Datasource(EncryptedStrGetterSetterMixin, BaseModel):
+class Datasource(EncryptedStrSetterMixin, BaseModel):
     class Config:
         extra = Extra.allow
 

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -1,0 +1,84 @@
+from typing import TYPE_CHECKING, Any, Dict
+
+from cryptography.fernet import InvalidToken
+from pydantic.utils import update_not_none
+from pydantic.validators import str_validator
+
+from app.core import security
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
+    from pydantic.typing import CallableGenerator
+
+
+class EncryptedStr(str):
+    """Representation of an encrypted string."""
+
+    def __new__(cls, value):
+        """
+        Create a string object from the given value.
+
+        We try to decrypt it to check if it's already an encrypted value,
+        e.g. if it comes from the database. If it is, we just set it as it.
+
+        Otherwise, we encrypt it immediately.
+        """
+        try:
+            security.decrypt_password(value)
+            return super(EncryptedStr, cls).__new__(cls, value)
+        except InvalidToken:
+            return super(EncryptedStr, cls).__new__(cls, security.encrypt_password(value))
+
+    @classmethod
+    def __modify_schema__(cls, field_schema: Dict[str, Any]) -> None:
+        update_not_none(
+            field_schema,
+            type="string",
+            writeOnly=True,
+        )
+
+    @classmethod
+    def __get_validators__(cls) -> 'CallableGenerator':
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, value: Any) -> 'EncryptedStr':
+        if isinstance(value, cls):
+            return value
+        value = str_validator(value)
+        return cls(value)
+
+    def __repr__(self) -> str:
+        return f"EncryptedStr('**********')"
+
+    def __eq__(self, other: Any) -> bool:
+        return isinstance(other, EncryptedStr) and self.get_decrypted_value() == other.get_decrypted_value()
+
+    def get_decrypted_value(self) -> str:
+        return security.decrypt_password(self)
+
+
+class EncryptedStrGetterSetterMixin:
+    """
+    Mixin to overload the setter method of Pydantic models
+    using an `EncryptedStr` field.
+
+    By default, when setting an attribute like this:
+
+    ```py
+    my_object.encrypted_value = "VALUE"
+    ```
+
+    Pydantic will just store it as a plain string without
+    respecting the type we gave on the model class.
+
+    We overload this behavior by checking if the field
+    we are currently setting has the `EncryptedStr` type.
+    If it does, we take care of instantiating a proper `EncryptedStr`
+    instance so our string is correctly encrypted.
+    """
+    def __setattr__(self: "BaseModel", name: str, value: Any) -> None:
+        field = self.__fields__.get(name)
+        if field and field.type_ == EncryptedStr:
+            return super().__setattr__(name, EncryptedStr(value))
+        return super().__setattr__(name, value)

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -58,7 +58,7 @@ class EncryptedStr(str):
         return security.decrypt_password(self)
 
 
-class EncryptedStrGetterSetterMixin:
+class EncryptedStrSetterMixin:
     """
     Mixin to overload the setter method of Pydantic models
     using an `EncryptedStr` field.


### PR DESCRIPTION
# Description

For security purposes, datasources passwords are encrypted in the database.

Currently, this feature involves quite a lot of manual operations to make sure we encrypt and decrypt the value at the right time. The goal of this proposal is to provide a "plug-and-play" way to support this and allow to easily encrypt arbitrary fields.

It consists of two things:
1. A new type, `EncryptedStr`, which is an overload of the standard `str` object. Its role is to automatically encrypt the string at instantiation. It also provides a `get_decrypted_value` method to get the decrypted, plain value.
2. A mixin for Pydantic models, `EncryptedStrSetterMixin`. Why is it needed? By default, when setting an attribute like this:

```py
my_object.encrypted_value = "VALUE"
```

Pydantic will just store it as a plain string without respecting the type we gave on the model class.

We overload this behavior by checking if the field we are currently setting has the `EncryptedStr` type. If it does, we take care of instantiating a proper `EncryptedStr` instance so our string is correctly encrypted.

We implemented those new helpers to encrypt/decrypt the `password` field of the datasources.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

The encryption algorithm stays the same, so it won't break already encrypted password.

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] All GitHub workflows have passed
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules