### PR TITLE
FIX: Set masked password to original password on updateDatasource

### DIFF
--- a/backend/app/api/api_v1/endpoints/datasource.py
+++ b/backend/app/api/api_v1/endpoints/datasource.py
@@ -205,8 +205,8 @@ def _update_datasource(datasource, key: str, test: bool):
 				# password hasn't changed, get it from existing datasource and decrypt password
 				datasource_for_test.password = original_datasource.password
 
-				# remove password so we don't update OpenSearch with *****
-				datasource_as_dict.pop("password")
+				# set password so we don't update OpenSearch with *****
+				datasource_as_dict["password"] = original_datasource.password
 
 		_test_datasource(datasource_for_test)
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,4 +2,4 @@ import uvicorn
 
 
 if __name__ == "__main__":
-    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True)
+    uvicorn.run("app.main:app", host="0.0.0.0", port=8000, reload=True, env_file="../docker/.env-local")


### PR DESCRIPTION
# Description
When updating a datasource and there are no changes made to the datasource password, a masked value is included in the request. When this happens, we should set `datasource.password` to the original password instead of removing the password property from `datasource`.

This fixes a bug where a validation error occurs because `password` is removed from the response object.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:
- [x] I have performed a self-review of my own code
- [x] All GitHub workflows have passed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules