### PR TITLE
Build docker images for multiple platforms

### DIFF
--- a/.github/workflows/build-and-publish-docker-images.yml
+++ b/.github/workflows/build-and-publish-docker-images.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           context: ./backend/
           file: ./backend/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.swiple-api-meta.outputs.tags }}
           labels: ${{ steps.swiple-api-meta.outputs.labels }}
@@ -74,6 +75,7 @@ jobs:
         with:
           context: ./frontend/
           file: ./frontend/Dockerfile.prod
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.swiple-ui-meta.outputs.tags }}
           labels: ${{ steps.swiple-ui-meta.outputs.labels }}

--- a/.github/workflows/build-and-publish-docker-images.yml
+++ b/.github/workflows/build-and-publish-docker-images.yml
@@ -17,6 +17,9 @@ jobs:
         name: Checkout
         uses: actions/checkout@v3
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
@@ -47,6 +50,9 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
Signed-off-by: Kenton Parton <kknoxparton@gmail.com>

# Description
Swiple should run optimally on all of the commonly used operating systems. Currently, Swiple docker images are only built for 1 OS. These changes will built Swiple for all common platforms to improve Swiple's performance and potentially reduce reported bugs.

## Type of change
- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] I have performed a self-review of my own code
- [x] All GitHub workflows have passed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules