### PR TITLE
Make datasource.description Optional

### DIFF
--- a/backend/app/models/datasource.py
+++ b/backend/app/models/datasource.py
@@ -20,7 +20,7 @@ class Engine(str, Enum):
 class DatasourceBase(BaseModel, KeyModel, CreateUpdateDateModel):
     engine: Engine
     datasource_name: str
-    description: str
+    description: Optional[str]
     created_by: Optional[str]
 
     def connection_string(self):


### PR DESCRIPTION
# Description
A datasource description is not required for connections to be established; therefore, it should not be a required field.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] All GitHub workflows have passed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules