### PR TITLE
Upgrade snowflake-sqlalchemy 1.4.0 -> 1.4.1

### DIFF
--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -1692,7 +1692,7 @@ secure-local-storage = ["keyring (!=16.1.0,<24.0.0)"]
 
 [[package]]
 name = "snowflake-sqlalchemy"
-version = "1.4.0"
+version = "1.4.1"
 description = "Snowflake SQLAlchemy Dialect"
 category = "main"
 optional = true
@@ -2028,7 +2028,7 @@ trino = ["trino"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9.0,<3.10"
-content-hash = "4d3ebf675f8590dd792ef2a042faee91521cc09b32f57d0ab760eaf2916030c5"
+content-hash = "c1120e1ee6df2d3df750c9b19d51b3617851e7bdcb8325a2f58a520a50c321e4"
 
 [metadata.files]
 aiohttp = [
@@ -3176,6 +3176,13 @@ pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
+    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
+    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
+    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
+    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
@@ -3242,6 +3249,7 @@ pyzmq = [
     {file = "pyzmq-23.2.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:48400b96788cdaca647021bf19a9cd668384f46e4d9c55cf045bdd17f65299c8"},
     {file = "pyzmq-23.2.1-cp37-cp37m-win32.whl", hash = "sha256:8a68f57b7a3f7b6b52ada79876be1efb97c8c0952423436e84d70cc139f16f0d"},
     {file = "pyzmq-23.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9e5bf6e7239fc9687239de7a283aa8b801ab85371116045b33ae20132a1325d6"},
+    {file = "pyzmq-23.2.1-cp38-cp38-macosx_10_15_universal2.whl", hash = "sha256:0ff6294e001129a9f22dcbfba186165c7e6f573c46de2704d76f873c94c65416"},
     {file = "pyzmq-23.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ffc6b1623d0f9affb351db4ca61f432dca3628a5ee015f9bf2bfbe9c6836881c"},
     {file = "pyzmq-23.2.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4d6f110c56f7d5b4d64dde3a382ae61b6d48174e30742859d8e971b18b6c9e5c"},
     {file = "pyzmq-23.2.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9269fbfe3a4eb2009199120861c4571ef1655fdf6951c3e7f233567c94e8c602"},
@@ -3394,8 +3402,8 @@ snowflake-connector-python = [
     {file = "snowflake_connector_python-2.7.11-cp39-cp39-win_amd64.whl", hash = "sha256:854d1658eeeb95bdbf039524b58e75362e3275baf14726fcd8364afd3d3e792f"},
 ]
 snowflake-sqlalchemy = [
-    {file = "snowflake-sqlalchemy-1.4.0.tar.gz", hash = "sha256:f48a284dfcd7466384db686e05276e338917f25b48e85e749ef9149d7464005a"},
-    {file = "snowflake_sqlalchemy-1.4.0-py2.py3-none-any.whl", hash = "sha256:4650e6d5d13f44a17b823861b5e042bddeea1c373dab9865d343e4caca151841"},
+    {file = "snowflake-sqlalchemy-1.4.1.tar.gz", hash = "sha256:7492b56e267aac4a52e244e771f2731e304b92d0d94acaaf4867a46e67e1bdeb"},
+    {file = "snowflake_sqlalchemy-1.4.1-py2.py3-none-any.whl", hash = "sha256:4142682e24d3937ca4ebe43da2467e71d112d7bfd20721871922c319f234cf34"},
 ]
 soupsieve = [
     {file = "soupsieve-2.3.2.post1-py3-none-any.whl", hash = "sha256:3b2503d3c7084a42b1ebd08116e5f81aadfaea95863628c80a3b774a11b7c759"},

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,7 +26,7 @@ PyYAML = "^6.0"
 
 psycopg2-binary = { version = ">=2.7.6", optional = true }
 snowflake-connector-python = { version = ">=2.7.11", optional = true }
-snowflake-sqlalchemy = { version = ">=1.4.0", optional = true }
+snowflake-sqlalchemy = { version = ">=1.4.1", optional = true }
 PyMySQL = { version = ">=0.9.3,<0.10", optional = true }
 pyathena = { version = ">=1.11", optional = true }
 sqlalchemy-redshift = { version = ">=0.7.7", optional = true }


### PR DESCRIPTION
# Description
Upgrade snowflake-sqlalchemy 1.4.0 -> 1.4.1

Version 1.4.0 has been yanked.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] All GitHub workflows have passed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules