### PR TITLE
[Breaking] Validation model update

### DIFF
--- a/backend/app/api/api_v1/endpoints/dataset.py
+++ b/backend/app/api/api_v1/endpoints/dataset.py
@@ -14,6 +14,7 @@ from app.repositories.base import NotFoundError
 from app.repositories.dataset import DatasetRepository, get_dataset_repository
 from app.repositories.datasource import DatasourceRepository, get_datasource_repository
 from app.repositories.expectation import ExpectationRepository, get_expectation_repository
+from app.repositories.validation import get_validation_repository, ValidationRepository
 from app.settings import settings
 from app.models.users import UserDB
 from app.core.runner import Runner, run_dataset_validation
@@ -148,10 +149,9 @@ def delete_dataset(
         request: Request,
         repository: DatasetRepository = Depends(get_dataset_repository),
         expectation_repository: ExpectationRepository = Depends(get_expectation_repository),
+        validation_repository: ValidationRepository = Depends(get_validation_repository)
 ):
-    body = {"query": {"match": {"dataset_id": key}}}
-
-    client.delete_by_query(index=settings.VALIDATION_INDEX, body=body)
+    validation_repository.delete_by_dataset(dataset_id=key)
     requests.delete(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules",
         params={"dataset_id": key},

--- a/backend/app/api/api_v1/endpoints/datasource.py
+++ b/backend/app/api/api_v1/endpoints/datasource.py
@@ -15,6 +15,7 @@ from app.models.users import UserDB
 from app.repositories.dataset import DatasetRepository, get_dataset_repository
 from app.repositories.datasource import DatasourceRepository, get_datasource_repository
 from app.repositories.expectation import ExpectationRepository, get_expectation_repository
+from app.repositories.validation import ValidationRepository, get_validation_repository
 from app.settings import settings
 from app import constants as c
 
@@ -127,7 +128,6 @@ def update_datasource(
 	return updated_datasource
 
 
-
 @router.delete("/{key}")
 def delete_datasource(
 		key: str,
@@ -135,9 +135,10 @@ def delete_datasource(
 		repository: DatasourceRepository = Depends(get_datasource_repository),
 		dataset_repository: DatasetRepository = Depends(get_dataset_repository),
 		expectation_repository: ExpectationRepository = Depends(get_expectation_repository),
+		validation_repository: ValidationRepository = Depends(get_validation_repository),
 ):
-	body = {"query": {"match": {"datasource_id": key}}}
-	client.delete_by_query(index=settings.VALIDATION_INDEX, body=body)
+
+	validation_repository.delete_by_datasource(datasource_id=key)
 	expectation_repository.delete_by_datasource(key)
 	dataset_repository.delete_by_datasource(key)
 	requests.delete(
@@ -151,7 +152,6 @@ def delete_datasource(
 		status_code=status.HTTP_200_OK,
 		content="datasource deleted"
 	)
-
 
 
 def _test_datasource(datasource: Datasource):

--- a/backend/app/api/api_v1/endpoints/expectation.py
+++ b/backend/app/api/api_v1/endpoints/expectation.py
@@ -81,7 +81,7 @@ def list_expectations(
     )
 
     if include_history:
-        validations: list[Validation] = validation_repository.query_by_filter(
+        validations = validation_repository.query_by_filter(
             datasource_id=datasource_id,
             dataset_id=dataset_id,
         )
@@ -183,7 +183,7 @@ def zip_expectations_and_validations(expectations: list[Expectation], validation
         expectations_as_dict[expectation.key] = expectation
 
     for validation in validations:
-        run_time = utils.string_to_military_time(validation.meta.run_id.run_time)
+        run_time = utils.string_to_utc_time(validation.meta.run_id.run_time)
 
         for result in validation.results:
             result_as_dict = result.dict()
@@ -202,11 +202,11 @@ def _table_level_expectation_already_exists(expectation: Expectation, repository
     # Duplicate Table level/ result_type="expectation", expectations are removed by GE when validations are run.
     # Because of this, we want to prevent duplicate table level expectations from being added.
     if expectation.result_type == c.EXPECTATION:
-        if len(repository.query_by_filter(
+        if repository.count_by_filter(
                 dataset_id=expectation.dataset_id,
                 enabled=True,
                 expectation_type=expectation.expectation_type
-        )) > 0:
+        ) > 0:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=f"Table level expectation_type '{expectation.expectation_type}' already exists"

--- a/backend/app/api/api_v1/endpoints/metrics.py
+++ b/backend/app/api/api_v1/endpoints/metrics.py
@@ -65,7 +65,7 @@ def top_issues():
                         {
                             "range": {
                                 "meta.run_id.run_time": {
-                                    "gte": "now-2d",
+                                    "gte": "now-1d",
                                     "lte": "now"
                                 }
                             }

--- a/backend/app/api/api_v1/endpoints/validation.py
+++ b/backend/app/api/api_v1/endpoints/validation.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, status
 from app.models.validation import Validation, Stats
 from app.repositories.validation import ValidationRepository, get_validation_repository
 from fastapi.param_functions import Depends
@@ -17,6 +17,12 @@ def list_validations(
         dataset_id: Optional[str] = None,
         repository: ValidationRepository = Depends(get_validation_repository),
 ):
+    if not dataset_id and not datasource_id:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Expected either datasource_id or dataset_id"
+        )
+
     return repository.query_by_filter(
         datasource_id=datasource_id,
         dataset_id=dataset_id,

--- a/backend/app/api/api_v1/endpoints/validation.py
+++ b/backend/app/api/api_v1/endpoints/validation.py
@@ -1,8 +1,8 @@
-from fastapi import APIRouter, status, HTTPException
-from fastapi.responses import JSONResponse
+from typing import Optional
 
-from app.db.client import client
-from app.settings import settings
+from fastapi import APIRouter
+from app.models.validation import Validation, Stats
+from app.repositories.validation import ValidationRepository, get_validation_repository
 from fastapi.param_functions import Depends
 from app.core.users import current_active_user
 
@@ -11,148 +11,40 @@ router = APIRouter(
 )
 
 
-@router.get("")
+@router.get("", response_model=list[Validation])
 def list_validations(
-        datasource_id: str,
-        dataset_id: str,
+        datasource_id: Optional[str] = None,
+        dataset_id: Optional[str] = None,
+        repository: ValidationRepository = Depends(get_validation_repository),
 ):
-    validations_response = client.search(
-        index=settings.VALIDATION_INDEX,
-        body=validations_query_body(dataset_id, datasource_id)
-    )
-    validations_list = [validation["_source"] for validation in validations_response["hits"]["hits"]]
-
-    return JSONResponse(status_code=status.HTTP_200_OK, content=validations_list)
-
-
-@router.get("/statistics")
-def validations(dataset_id: str):
-    query = {
-        "size": 0,
-        "query": {
-            "bool": {
-                "must": [
-                    {"match": {"dataset_id.keyword": dataset_id}},
-                    {"range": {"run_date": {"gte": "now-31d", "lte": "now"}}},
-                    {"match": {"exception_info.raised_exception": "false"}},
-                ]
-            }
-        },
-        "aggs": {
-            "31_day": {
-                "filter": {
-                    "range": {"run_date": {"gte": "now-31d", "lte": "now"}}
-                },
-                "aggs": {
-                    "success_counts": {
-                        "terms": {"field": "success"}
-                    }
-                }
-            },
-            "7_day": {
-                "filter": {"range": {"run_date": {"gte": "now-7d", "lte": "now"}}},
-                "aggs": {
-                    "success_counts": {
-                        "terms": {"field": "success"}
-                    }
-                }
-            },
-            "1_day": {
-                "filter": {
-                    "range": {"run_date": {"gte": "now-1d", "lte": "now"}},
-                },
-                "aggs": {
-                    "success_counts": {
-                        "terms": {"field": "success"},
-                    }
-                }
-            },
-            "validation_counts": {
-                "date_histogram": {
-                    "field": "run_date",
-                    "calendar_interval": "1d",
-                    "format": "yyyy-MM-dd'T'HH:mm:ssZZZZZ",  # yyyy-MM-dd HH:mm:ss.SSSSSSZZZZZ
-                },
-                "aggs": {
-                    "1_day": {
-                        "terms": {
-                            "field": "success",
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    validation_stats = client.search(
-        index=settings.VALIDATION_INDEX,
-        body=query,
+    return repository.query_by_filter(
+        datasource_id=datasource_id,
+        dataset_id=dataset_id,
     )
 
-    aggs = validation_stats["aggregations"]
+
+@router.get("/statistics", response_model=Stats)
+def validations(
+        dataset_id: str,
+        repository: ValidationRepository = Depends(get_validation_repository),
+
+):
+    statistics = repository.statistics(
+        dataset_id=dataset_id,
+    )
+
+    aggs = statistics["aggregations"]
 
     validations_dataset = []
     for daily_bucket in aggs["validation_counts"]["buckets"]:
-        objective_pass_rate = calculate_objective_pass_rate(
-            buckets=daily_bucket["1_day"]["buckets"],
-            doc_count=daily_bucket["doc_count"],
-        )
+        objective_pass_rate = daily_bucket["1_day"]["value"]
         validations_dataset.append([daily_bucket["key_as_string"], objective_pass_rate])
 
-    one_day_metric = calculate_objective_pass_rate(
-        buckets=aggs["1_day"]["success_counts"]["buckets"],
-        doc_count=aggs["1_day"]["doc_count"]
-    )
-
-    seven_day_metric = calculate_objective_pass_rate(
-        buckets=aggs["7_day"]["success_counts"]["buckets"],
-        doc_count=aggs["7_day"]["doc_count"]
-    )
-
-    thirty_one_day_metric = calculate_objective_pass_rate(
-        buckets=aggs["31_day"]["success_counts"]["buckets"],
-        doc_count=aggs["31_day"]["doc_count"]
-    )
-
-    return JSONResponse(
-        status_code=status.HTTP_200_OK,
-        content={
-            "1_day_avg": one_day_metric,
-            "7_day_avg": seven_day_metric,
-            "31_day_avg": thirty_one_day_metric,
+    return Stats(
+        **{
+            "1_day_avg": aggs["1_day"]["success_counts"]["value"],
+            "7_day_avg": aggs["7_day"]["success_counts"]["value"],
+            "31_day_avg": aggs["31_day"]["success_counts"]["value"],
             "validations": validations_dataset,
         }
     )
-
-
-def validations_query_body(datasource_id: str = None, dataset_id: str = None, period: int = 14):
-    query = {
-        "size": 2000,
-        "query": {
-            "bool": {
-                "must": [
-                    {"range": {"run_date": {"gte": f"now-{period}d", "lte": "now"}}},
-                ]
-            }
-        },
-        "sort": [{"run_date": "asc"}]
-    }
-    if not dataset_id and not datasource_id:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Expected either datasource_id or dataset_id"
-        )
-
-    if dataset_id:
-        query["query"]["bool"]["must"].append({"match": {"dataset_id.keyword": dataset_id}})
-
-    if datasource_id:
-        query["query"]["bool"]["must"].append({"match": {"datasource_id.keyword": datasource_id}})
-
-    return query
-
-
-def calculate_objective_pass_rate(buckets: list, doc_count: int):
-    for bucket in buckets:
-        if bucket["key_as_string"] == "true":
-            return bucket["doc_count"] / doc_count * 100

--- a/backend/app/core/runner.py
+++ b/backend/app/core/runner.py
@@ -149,7 +149,6 @@ class Runner:
             utils.list_to_string_mapper(result)
             result["expectation_id"] = result["expectation_config"]["meta"].pop("expectation_id")
 
-        print(validation)
         return Validation(**validation)
 
     def get_data_context_config(self):
@@ -247,7 +246,7 @@ def run_dataset_validation(dataset_id: str):
         runner_expectation["meta"] = {"expectation_id": expectation.key}
         runner_expectations.append(runner_expectation)
 
-    validation: Validation = Runner(
+    validation = Runner(
         datasource=datasource,
         batch=dataset,
         meta=meta,

--- a/backend/app/core/runner.py
+++ b/backend/app/core/runner.py
@@ -16,6 +16,7 @@ from pandas import isnull
 from app import utils
 from app.db.client import client
 from app.models.datasource import Engine
+from app.models.validation import Validation
 from app.repositories.dataset import DatasetRepository
 from app.repositories.datasource import DatasourceRepository
 from app.repositories.expectation import ExpectationRepository
@@ -74,7 +75,7 @@ class Runner:
 
         batch_request = self.get_batch_request()
 
-        suite: ExpectationSuite = context.create_expectation_suite("suite", overwrite_existing=True)
+        suite: ExpectationSuite = context.create_expectation_suite("default", overwrite_existing=True)
 
         try:
             validator = context.get_validator(
@@ -100,11 +101,11 @@ class Runner:
                     record[column] = None
         return {'columns': list(columns), 'rows': rows}
 
-    def validate(self):
+    def validate(self) -> Validation:
         data_context_config = self.get_data_context_config()
         context = BaseDataContext(project_config=data_context_config)
 
-        suite: ExpectationSuite = context.create_expectation_suite("suite", overwrite_existing=True)
+        suite: ExpectationSuite = context.create_expectation_suite("default", overwrite_existing=True)
 
         for expectation in self.expectations:
             if self.batch.runtime_parameters:
@@ -131,9 +132,13 @@ class Runner:
             batch_request=batch_request, expectation_suite=suite,
         )
 
-        results = validator.validate().to_json_dict()["results"]
+        validation = validator.validate().to_json_dict()
+        validation["meta"]["run_id"]["run_time"] = utils.remove_t_from_date_string(
+            validation["meta"]["run_id"]["run_time"])
+        validation["meta"]["run_id"]["run_name"] = str(uuid.uuid4())
+        validation["meta"].update(self.identifiers)
 
-        for result in results:
+        for result in validation["results"]:
             # GE "mostly" is synonymous for Swiple "objective"
             if result["expectation_config"]["kwargs"].get("mostly"):
                 result["expectation_config"]["kwargs"]["objective"] = result["expectation_config"]["kwargs"].pop("mostly")
@@ -142,10 +147,10 @@ class Runner:
                 result["result"]["observed_value_list"] = result["result"].pop("observed_value")
 
             utils.list_to_string_mapper(result)
-            self.identifiers["expectation_id"] = result["expectation_config"]["meta"].pop("expectation_id")
-            result.update(self.identifiers)
+            result["expectation_id"] = result["expectation_config"]["meta"].pop("expectation_id")
 
-        return results
+        print(validation)
+        return Validation(**validation)
 
     def get_data_context_config(self):
         # Snowflake SQLAlchemy connector requires the schema in the connection string in order to create TEMP tables.
@@ -227,8 +232,6 @@ def run_dataset_validation(dataset_id: str):
     expectations = ExpectationRepository(client).query_by_filter(dataset_id=dataset.key, enabled=True)
 
     identifiers = {
-        "run_date": utils.current_time(),
-        "run_id": uuid.uuid4(),
         "datasource_id": datasource.key,
         "dataset_id": dataset.key,
     }
@@ -244,7 +247,7 @@ def run_dataset_validation(dataset_id: str):
         runner_expectation["meta"] = {"expectation_id": expectation.key}
         runner_expectations.append(runner_expectation)
 
-    results = Runner(
+    validation: Validation = Runner(
         datasource=datasource,
         batch=dataset,
         meta=meta,
@@ -252,11 +255,11 @@ def run_dataset_validation(dataset_id: str):
         identifiers=identifiers,
     ).validate()
 
-    bulk(
-        client,
-        results,
+    client.index(
         index=settings.VALIDATION_INDEX,
+        id=str(uuid.uuid4()),
+        body=validation.dict(),
         refresh="wait_for",
     )
 
-    return results
+    return validation

--- a/backend/app/models/dataset.py
+++ b/backend/app/models/dataset.py
@@ -6,6 +6,7 @@ from pydantic import Field, constr, validator
 from app.models.base_model import BaseModel, CreateUpdateDateModel, KeyModel
 from app.models.datasource import Engine
 
+
 class RuntimeParameters(BaseModel):
 	schema_name: str = Field(alias="schema")
 	query: Optional[str]

--- a/backend/app/models/validation.py
+++ b/backend/app/models/validation.py
@@ -1,0 +1,101 @@
+from typing import Optional, Any, List
+
+from pydantic.config import Extra
+from pydantic.fields import Field
+
+from app.models.base_model import BaseModel
+
+
+class Stats(BaseModel):
+    one_day_avg: Optional[float] = Field(alias="1_day_avg")
+    seven_day_avg: Optional[float] = Field(alias="7_day_avg")
+    thirty_one_day_avg: Optional[float] = Field(alias="31_day_avg")
+    validations: Optional[list[Any]]
+
+
+class Statistics(BaseModel):
+    evaluated_expectations: int
+    successful_expectations: int
+    unsuccessful_expectations: int
+    success_percent: float
+
+
+class ActiveBatchDefinition(BaseModel):
+    datasource_name: str
+    data_connector_name: str
+    data_asset_name: str
+    batch_identifiers: dict
+
+
+class RunId(BaseModel):
+    class Config:
+        extra = Extra.allow
+    run_time: str
+    run_name: str
+
+
+class BatchSpec(BaseModel):
+    class Config:
+        extra = Extra.allow
+
+    data_asset_name: str
+    create_temp_table: bool
+    table_name: Optional[str]
+    batch_identifiers: Optional[dict]
+    schema_name: Optional[str]
+    type: Optional[str]
+    query: Optional[str]
+    temp_table_schema_name: Optional[bool]
+
+
+class Meta(BaseModel):
+    great_expectations_version: str
+    expectation_suite_name: str
+    run_id: RunId
+    batch_spec: dict
+    batch_markers: dict
+    active_batch_definition: ActiveBatchDefinition
+    validation_time: str
+    checkpoint_name: Optional[str]
+    datasource_id: str
+    dataset_id: str
+
+
+class ExceptionInfo(BaseModel):
+    raised_exception: bool
+    exception_traceback: Optional[str]
+    exception_message: Optional[str]
+
+
+class Kwargs(BaseModel):
+    class Config:
+        extra = Extra.allow
+
+    result_format: str
+    include_config: bool
+    catch_exceptions: bool
+
+
+class ExpectationConfig(BaseModel):
+    kwargs: Kwargs
+    expectation_type: str
+    meta: dict
+
+
+class Result(BaseModel):
+    exception_info: ExceptionInfo
+    success: bool
+    expectation_config: ExpectationConfig
+    result: dict[str, Any]
+    meta: dict[str, Any]
+    expectation_id: str
+
+
+class Validation(BaseModel):
+    meta: Meta
+    statistics: Statistics
+    results: List[Result]
+    success: bool
+    evaluation_parameters: dict
+
+

--- a/backend/app/opensearch.yaml
+++ b/backend/app/opensearch.yaml
@@ -112,6 +112,12 @@ validations:
   index_name: validations
   mappings:
     properties:
-      run_date:
-        format: yyyy-MM-dd HH:mm:ss.SSSSSSZZZZZ
-        type: date
+      meta:
+        type: object
+        properties:
+          run_id:
+            type: object
+            properties:
+              run_time:
+                format: yyyy-MM-dd HH:mm:ss.SSSSSSZZZZZ
+                type: date

--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -29,7 +29,7 @@ class BaseRepository(Generic[M]):
         ]
 
     def count(self, body: dict[str, Any]) -> int:
-        return self.client.count(index=self.index, body=body)
+        return self.client.count(index=self.index, body=body)["count"]
 
     def get(self, id: str) -> M:
         try:

--- a/backend/app/repositories/expectation.py
+++ b/backend/app/repositories/expectation.py
@@ -19,6 +19,7 @@ class ExpectationRepository(BaseRepository[Expectation]):
         suggested: Optional[bool] = None,
         enabled: Optional[bool] = None,
         asc: Optional[bool] = False,
+        expectation_type: Optional[str] = None
     ) -> list[Expectation]:
         direction = "asc" if asc else "desc"
         sort_by_key: str = "expectation_type"
@@ -37,9 +38,13 @@ class ExpectationRepository(BaseRepository[Expectation]):
         if dataset_id is not None:
             query["query"]["bool"]["must"].append({"match": {"dataset_id": dataset_id}})
 
+        if expectation_type is not None:
+            query["query"]["bool"]["must"].append({"match": {"expectation_type": expectation_type}})
+
         return super().query(query, size=1000)
 
-    def delete_by_filter(self,
+    def delete_by_filter(
+        self,
         *,
         datasource_id: Optional[str] = None,
         dataset_id: Optional[str] = None,

--- a/backend/app/repositories/expectation.py
+++ b/backend/app/repositories/expectation.py
@@ -23,25 +23,35 @@ class ExpectationRepository(BaseRepository[Expectation]):
     ) -> list[Expectation]:
         direction = "asc" if asc else "desc"
         sort_by_key: str = "expectation_type"
+        sort = {"sort": [{sort_by_key: direction}]}
 
-        query = {"query": {"bool": {"must": []}}, "sort": [{sort_by_key: direction}]}
-
-        if enabled is not None:
-            query["query"]["bool"]["must"].append({"match": {"enabled": enabled}})
-
-        if suggested is not None:
-            query["query"]["bool"]["must"].append({"match": {"suggested": suggested}})
-
-        if datasource_id is not None:
-            query["query"]["bool"]["must"].append({"match": {"datasource_id": datasource_id}})
-
-        if dataset_id is not None:
-            query["query"]["bool"]["must"].append({"match": {"dataset_id": dataset_id}})
-
-        if expectation_type is not None:
-            query["query"]["bool"]["must"].append({"match": {"expectation_type": expectation_type}})
-
+        query = self._build_query_filter(
+            datasource_id=datasource_id,
+            dataset_id=dataset_id,
+            suggested=suggested,
+            enabled=enabled,
+            expectation_type=expectation_type,
+            sort=sort,
+        )
         return super().query(query, size=1000)
+
+    def count_by_filter(
+        self,
+        *,
+        datasource_id: Optional[str] = None,
+        dataset_id: Optional[str] = None,
+        suggested: Optional[bool] = None,
+        enabled: Optional[bool] = None,
+        expectation_type: Optional[str] = None
+    ):
+        query = self._build_query_filter(
+            datasource_id=datasource_id,
+            dataset_id=dataset_id,
+            suggested=suggested,
+            enabled=enabled,
+            expectation_type=expectation_type,
+        )
+        return super().count(query)
 
     def delete_by_filter(
         self,
@@ -51,19 +61,12 @@ class ExpectationRepository(BaseRepository[Expectation]):
         suggested: Optional[bool] = None,
         enabled: Optional[bool] = None,
     ):
-        query = {"query": {"bool": {"must": []}}}
-
-        if enabled is not None:
-            query["query"]["bool"]["must"].append({"match": {"enabled": enabled}})
-
-        if suggested is not None:
-            query["query"]["bool"]["must"].append({"match": {"suggested": suggested}})
-
-        if datasource_id is not None:
-            query["query"]["bool"]["must"].append({"match": {"datasource_id": datasource_id}})
-
-        if dataset_id is not None:
-            query["query"]["bool"]["must"].append({"match": {"dataset_id": dataset_id}})
+        query = self._build_query_filter(
+            datasource_id=datasource_id,
+            dataset_id=dataset_id,
+            suggested=suggested,
+            enabled=enabled,
+        )
 
         return super().delete_by_query(query)
 
@@ -82,6 +85,38 @@ class ExpectationRepository(BaseRepository[Expectation]):
         object = ExpectationInput.parse_obj(d).__root__
         object.documentation = object._documentation()
         return object
+
+    @staticmethod
+    def _build_query_filter(
+        *,
+        datasource_id: Optional[str] = None,
+        dataset_id: Optional[str] = None,
+        suggested: Optional[bool] = None,
+        enabled: Optional[bool] = None,
+        expectation_type: Optional[str] = None,
+        sort: Optional[dict] = None,
+    ):
+        if sort is None:
+            sort = {}
+
+        query = {"query": {"bool": {"must": []}}, **sort}
+
+        if enabled is not None:
+            query["query"]["bool"]["must"].append({"match": {"enabled": enabled}})
+
+        if suggested is not None:
+            query["query"]["bool"]["must"].append({"match": {"suggested": suggested}})
+
+        if datasource_id is not None:
+            query["query"]["bool"]["must"].append({"match": {"datasource_id": datasource_id}})
+
+        if dataset_id is not None:
+            query["query"]["bool"]["must"].append({"match": {"dataset_id": dataset_id}})
+
+        if expectation_type is not None:
+            query["query"]["bool"]["must"].append({"match": {"expectation_type": expectation_type}})
+
+        return query
 
 
 get_expectation_repository = get_repository(ExpectationRepository)

--- a/backend/app/repositories/validation.py
+++ b/backend/app/repositories/validation.py
@@ -62,7 +62,6 @@ class ValidationRepository(BaseRepository[Validation]):
                     "must": [
                         {"match": {"meta.dataset_id.keyword": dataset_id}},
                         {"range": {"meta.run_id.run_time": {"gte": "now-31d", "lte": "now"}}},
-                        # {"match": {"exception_info.raised_exception": "false"}},
                     ]
                 }
             },
@@ -99,7 +98,7 @@ class ValidationRepository(BaseRepository[Validation]):
                     "date_histogram": {
                         "field": "meta.run_id.run_time",
                         "calendar_interval": "1d",
-                        "format": "yyyy-MM-dd'T'HH:mm:ssZZZZZ",  # yyyy-MM-dd HH:mm:ss.SSSSSSZZZZZ
+                        "format": "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
                     },
                     "aggs": {
                         "1_day": {
@@ -117,8 +116,6 @@ class ValidationRepository(BaseRepository[Validation]):
         )
 
     def _get_object_from_dict(self, d: dict[str, Any], *, id: Optional[str] = None) -> Validation:
-        # if id is not None:
-        #     d["key"] = id
         return Validation.parse_obj(d)
 
     def _get_dict_from_object(self, object: Validation) -> dict[str, Any]:

--- a/backend/app/repositories/validation.py
+++ b/backend/app/repositories/validation.py
@@ -1,0 +1,113 @@
+from typing import Any, Optional
+
+from app.repositories.base import BaseRepository, get_repository
+from fastapi import HTTPException, status
+from app.models.validation import Validation
+from app.settings import settings
+
+
+class ValidationRepository(BaseRepository[Validation]):
+    model_class = Validation
+    index = settings.VALIDATION_INDEX
+
+    def query_by_filter(
+        self,
+        datasource_id: str = None,
+        dataset_id: str = None,
+        period: int = 14,
+    ):
+        query = {
+            "query": {
+                "bool": {
+                    "must": [
+                        {"range": {"meta.run_id.run_time": {"gte": f"now-{period}d", "lte": "now"}}},
+                    ]
+                }
+            },
+            "sort": [{"meta.run_id.run_time": "asc"}]
+        }
+        if not dataset_id and not datasource_id:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Expected either datasource_id or dataset_id"
+            )
+
+        if dataset_id:
+            query["query"]["bool"]["must"].append({"match": {"meta.dataset_id.keyword": dataset_id}})
+
+        if datasource_id:
+            query["query"]["bool"]["must"].append({"match": {"meta.datasource_id.keyword": datasource_id}})
+
+        return super().query(query, size=2000)
+
+    def statistics(self, dataset_id):
+        query = {
+            "query": {
+                "bool": {
+                    "must": [
+                        {"match": {"meta.dataset_id.keyword": dataset_id}},
+                        {"range": {"meta.run_id.run_time": {"gte": "now-31d", "lte": "now"}}},
+                        # {"match": {"exception_info.raised_exception": "false"}},
+                    ]
+                }
+            },
+            "aggs": {
+                "31_day": {
+                    "filter": {
+                        "range": {"meta.run_id.run_time": {"gte": "now-31d", "lte": "now"}}
+                    },
+                    "aggs": {
+                        "success_counts": {
+                            "avg": {"field": "statistics.success_percent"}
+                        }
+                    }
+                },
+                "7_day": {
+                    "filter": {"range": {"meta.run_id.run_time": {"gte": "now-7d", "lte": "now"}}},
+                    "aggs": {
+                        "success_counts": {
+                            "avg": {"field": "statistics.success_percent"}
+                        }
+                    }
+                },
+                "1_day": {
+                    "filter": {
+                        "range": {"meta.run_id.run_time": {"gte": "now-1d", "lte": "now"}},
+                    },
+                    "aggs": {
+                        "success_counts": {
+                            "avg": {"field": "statistics.success_percent"},
+                        }
+                    }
+                },
+                "validation_counts": {
+                    "date_histogram": {
+                        "field": "meta.run_id.run_time",
+                        "calendar_interval": "1d",
+                        "format": "yyyy-MM-dd'T'HH:mm:ssZZZZZ",  # yyyy-MM-dd HH:mm:ss.SSSSSSZZZZZ
+                    },
+                    "aggs": {
+                        "1_day": {
+                            "avg": {
+                                "field": "statistics.success_percent",
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return self.client.search(
+            index=settings.VALIDATION_INDEX,
+            body=query,
+        )
+
+    def _get_object_from_dict(self, d: dict[str, Any], *, id: Optional[str] = None) -> Validation:
+        # if id is not None:
+        #     d["key"] = id
+        return Validation.parse_obj(d)
+
+    def _get_dict_from_object(self, object: Validation) -> dict[str, Any]:
+        return object.dict()
+
+
+get_validation_repository = get_repository(ValidationRepository)

--- a/backend/app/repositories/validation.py
+++ b/backend/app/repositories/validation.py
@@ -26,11 +26,6 @@ class ValidationRepository(BaseRepository[Validation]):
             },
             "sort": [{"meta.run_id.run_time": "asc"}]
         }
-        if not dataset_id and not datasource_id:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Expected either datasource_id or dataset_id"
-            )
 
         if dataset_id:
             query["query"]["bool"]["must"].append({"match": {"meta.dataset_id.keyword": dataset_id}})

--- a/backend/app/repositories/validation.py
+++ b/backend/app/repositories/validation.py
@@ -35,6 +35,26 @@ class ValidationRepository(BaseRepository[Validation]):
 
         return super().query(query, size=2000)
 
+    def delete_by_filter(
+        self,
+        dataset_id: str = None,
+        datasource_id: str = None,
+    ):
+        query = {"query": {"bool": {"must": []}}}
+
+        if dataset_id is not None:
+            query["query"]["bool"]["must"].append({"match": {"meta.dataset_id.keyword": dataset_id}})
+        if datasource_id is not None:
+            query["query"]["bool"]["must"].append({"match": {"meta.datasource_id.keyword": datasource_id}})
+
+        return super().delete_by_query(query)
+
+    def delete_by_dataset(self, dataset_id: str):
+        return self.delete_by_filter(dataset_id=dataset_id)
+
+    def delete_by_datasource(self, datasource_id: str):
+        return self.delete_by_filter(datasource_id=datasource_id)
+
     def statistics(self, dataset_id):
         query = {
             "query": {

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -7,13 +7,22 @@ from re import search
 import emails
 from emails.template import JinjaTemplate
 from pathlib import Path
-from sqlalchemy.exc import ProgrammingError, OperationalError
 import json
 import pytz
 
 
 def current_time():
     return str(datetime.datetime.utcnow().replace(tzinfo=pytz.utc))
+
+
+def remove_t_from_date_string(date_string) -> datetime:
+    """
+    Converts a date string in the format
+    2021-10-11T09:10:44.330614+00:00
+    to
+    2021-10-11 09:10:44.330614+00:00
+    """
+    return date_string.replace("T", " ")
 
 
 def string_to_utc_time(date_string):

--- a/backend/app/utils.py
+++ b/backend/app/utils.py
@@ -26,14 +26,6 @@ def remove_t_from_date_string(date_string) -> datetime:
 
 
 def string_to_utc_time(date_string):
-    return datetime.datetime.strptime(date_string, "%Y-%m-%dT%H:%M:%S.%f%z")
-
-
-def days_between_dates(start_date: datetime, end_date: datetime):
-    return (end_date - start_date).days
-
-
-def string_to_military_time(date_string):
     """
     Converts a date string in the format
     2021-10-11 09:10:44.330614+00:00
@@ -41,6 +33,10 @@ def string_to_military_time(date_string):
     2021-10-11T09:10:44.330614Z
     """
     return datetime.datetime.strptime(date_string, "%Y-%m-%d %H:%M:%S.%f%z").strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def days_between_dates(start_date: datetime, end_date: datetime):
+    return (end_date - start_date).days
 
 
 def add_limit_clause(query):

--- a/frontend/src/screens/dashboard/components/TopIssues.jsx
+++ b/frontend/src/screens/dashboard/components/TopIssues.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Card, Table } from 'antd';
+import {
+  Card, Empty, Table,
+} from 'antd';
 import { Link } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -49,6 +51,11 @@ function TopIssues({ loading, data }) {
           pageSize: 5,
         }}
         rowKey={() => uuidv4()}
+        locale={{
+          emptyText: (
+            <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="No issues here" />
+          ),
+        }}
       />
     </Card>
   );

--- a/frontend/src/screens/dataset/components/ExpectationHistory.jsx
+++ b/frontend/src/screens/dataset/components/ExpectationHistory.jsx
@@ -27,7 +27,7 @@ function ExpectationHistory({ validations, resultType }) {
     }
 
     return {
-      value: [row.run_date, resultValue],
+      value: [row.run_time, resultValue],
       itemStyle: {
         color,
       },
@@ -54,7 +54,7 @@ function ExpectationHistory({ validations, resultType }) {
         percentageValue(validations[i]),
       );
       values.objectiveValues.push(
-        [validations[i].run_date, objectiveValue(validations[i])],
+        [validations[i].run_time, objectiveValue(validations[i])],
       );
     }
     return values;

--- a/frontend/src/screens/dataset/index.jsx
+++ b/frontend/src/screens/dataset/index.jsx
@@ -278,6 +278,9 @@ const Dataset = withRouter(() => {
                     setSuggestions(suggestions.filter((item) => item.key !== record.key));
                     setRefreshExpectations(true);
                     resolve();
+                  } else if (response.status === 422) {
+                    message.warn(response.data.detail, 10);
+                    resolve();
                   }
                 }).catch(() => reject());
               })}

--- a/frontend/src/screens/datasetOverview/components/DatasetModal.jsx
+++ b/frontend/src/screens/datasetOverview/components/DatasetModal.jsx
@@ -196,7 +196,7 @@ function DatasetModal({
               <img
                 style={{ position: 'relative' }}
                 src={imgPath}
-                alt="Girl in a jacket"
+                alt="Engine Icon"
                 width="20"
                 height="20"
               />


### PR DESCRIPTION
# Description
The existing validation structure contains just the expectation details and its results. With these changes we gain a lot more metadata about the validation supporting longer term features such as actions, replay, local client.

This is a breaking change. All existing validations will need to be removed and can be removed with the following OpenSearch query.

```
POST validations/_delete_by_query
{
  "size": 10000, 
  "query": {
    "match_all": {}
  }
}
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] All GitHub workflows have passed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules