### PR TITLE
Exclude Expectation.documentation from inserted data

### DIFF
--- a/backend/app/api/api_v1/endpoints/expectation.py
+++ b/backend/app/api/api_v1/endpoints/expectation.py
@@ -22,6 +22,7 @@ router = APIRouter(
     dependencies=[Depends(current_active_user)]
 )
 
+
 async def get_expectation_payload(expectation: ExpectationInput) -> Expectation:
     return expectation.__root__
 

--- a/backend/app/repositories/expectation.py
+++ b/backend/app/repositories/expectation.py
@@ -77,6 +77,7 @@ class ExpectationRepository(BaseRepository[Expectation]):
         d = object.dict(by_alias=True)
         kwargs = object.kwargs
         d["kwargs"] = kwargs.json() if isinstance(kwargs, BaseModel) else json.dumps(kwargs)
+        del d["documentation"]
         return d
 
     def _get_object_from_dict(self, d: dict[str, Any], *, id: Optional[str] = None) -> Expectation:

--- a/backend/app/repositories/expectation.py
+++ b/backend/app/repositories/expectation.py
@@ -74,10 +74,9 @@ class ExpectationRepository(BaseRepository[Expectation]):
         return self.delete_by_filter(datasource_id=datasource_id)
 
     def _get_dict_from_object(self, object: Expectation) -> dict[str, Any]:
-        d = object.dict(by_alias=True)
+        d = object.dict(by_alias=True, exclude={"documentation"})
         kwargs = object.kwargs
         d["kwargs"] = kwargs.json() if isinstance(kwargs, BaseModel) else json.dumps(kwargs)
-        del d["documentation"]
         return d
 
     def _get_object_from_dict(self, d: dict[str, Any], *, id: Optional[str] = None) -> Expectation:


### PR DESCRIPTION
# Description
Expectation.documentation is a field we want to retrieve at runtime instead of storing it in a db. The reason being that it provides flexibility to changes in expectation names and the documentation field without having to modify db data.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] All GitHub workflows have passed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules