### PR TITLE
Add /api/v1/health endpoint

### DIFF
--- a/backend/app/api/api_v1/endpoints/health.py
+++ b/backend/app/api/api_v1/endpoints/health.py
@@ -1,0 +1,10 @@
+from fastapi import APIRouter
+from starlette.responses import JSONResponse
+
+
+router = APIRouter()
+
+
+@router.get("/health", name="Health check")
+def health():
+    return JSONResponse(status_code=200)

--- a/backend/app/api/api_v1/scheduler_router.py
+++ b/backend/app/api/api_v1/scheduler_router.py
@@ -1,5 +1,6 @@
-from app.api.api_v1.endpoints import scheduler
+from app.api.api_v1.endpoints import health, scheduler
 from fastapi import APIRouter
 
 router = APIRouter()
+router.include_router(health.router, tags=["Health"])
 router.include_router(scheduler.router, prefix="/schedules", tags=["Schedules"])

--- a/backend/app/api/api_v1/swiple_router.py
+++ b/backend/app/api/api_v1/swiple_router.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 from app.api.api_v1.endpoints import (
+    health,
     auth,
     dataset,
     datasource,
@@ -14,6 +15,7 @@ from app.api.api_v1.endpoints import (
 )
 
 router = APIRouter()
+router.include_router(health.router, tags=["Health"])
 router.include_router(auth.router, prefix="/auth", tags=["Auth"])
 router.include_router(datasource.router, prefix="/datasources", tags=["Data Sources"])
 router.include_router(dataset.router, prefix="/datasets", tags=["Datasets"])

--- a/backend/tests/test_api_v1_health.py
+++ b/backend/tests/test_api_v1_health.py
@@ -1,0 +1,11 @@
+import httpx
+import pytest
+from fastapi import status
+
+
+@pytest.mark.asyncio
+class TestGetHealth:
+    async def test_unauthorized(self, test_client: httpx.AsyncClient):
+        response = await test_client.get("/api/v1/health")
+
+        assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
# Description
/health check endpoints are commonly used by application load balancers to determine whether an application is health or not. We are adding the endpoint /api/v1/health to support this use case.

## Type of change

 Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] All GitHub workflows have passed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules