### PR TITLE
Increase minimum scheduling period

### DIFF
--- a/backend/app/models/schedule.py
+++ b/backend/app/models/schedule.py
@@ -19,7 +19,7 @@ class IntervalTrigger(BaseModel):
     trigger: Literal["interval"]
     start_date: Optional[datetime] = Field(description=c.START_DATE)
     end_date: Optional[datetime] = Field(description=c.END_DATE)
-    seconds: Optional[int] = Field(description=c.SECONDS)
+    seconds: Optional[int] = Field(0, description=c.SECONDS, const=True)
     minutes: Optional[int] = Field(description=c.MINUTES)
     hours: Optional[int] = Field(description=c.HOURS)
     days: Optional[int] = Field(description=c.DAYS)
@@ -39,7 +39,7 @@ class CronTrigger(BaseModel):
     trigger: Literal["cron"]
     start_date: Optional[datetime] = Field(description=c.START_DATE)
     end_date: Optional[datetime] = Field(description=c.END_DATE)
-    second: Optional[str] = Field(description=c.SECOND)
+    second: Optional[str] = Field("0", description=c.SECONDS, const=True)
     minute: Optional[str] = Field(description=c.MINUTE)
     hour: Optional[str] = Field(description=c.HOUR)
     day: Optional[str] = Field(description=c.DAY)

--- a/frontend/src/screens/dataset/components/ScheduleModal.jsx
+++ b/frontend/src/screens/dataset/components/ScheduleModal.jsx
@@ -144,10 +144,6 @@ function ScheduleModal({
 
   const cronColumns = [
     {
-      title: 'Second',
-      dataIndex: 'second',
-    },
-    {
       title: 'Minute',
       dataIndex: 'minute',
     },
@@ -183,25 +179,25 @@ function ScheduleModal({
 
   const cronExamples = [
     {
-      second: '0', minute: '0', hour: '10', day: '*', week: '*', day_of_week: '*', month: '*', year: '*', meaning: 'Run at 10:00 am (UTC+0) every day',
+      minute: '0', hour: '10', day: '*', week: '*', day_of_week: '*', month: '*', year: '*', meaning: 'Run at 10:00 am (UTC+0) every day',
     },
     {
-      second: '0', minute: '15', hour: '12', day: '*', week: '*', day_of_week: '*', month: '*', year: '*', meaning: 'Run at 12:15 pm (UTC+0) every day',
+      minute: '15', hour: '12', day: '*', week: '*', day_of_week: '*', month: '*', year: '*', meaning: 'Run at 12:15 pm (UTC+0) every day',
     },
     {
-      second: '0', minute: '0', hour: '18', day: '*', week: '*', day_of_week: 'MON-FRI', month: '*', year: '*', meaning: 'Run at 6:00 pm (UTC+0) every Monday through Friday',
+      minute: '0', hour: '18', day: '*', week: '*', day_of_week: 'MON-FRI', month: '*', year: '*', meaning: 'Run at 6:00 pm (UTC+0) every Monday through Friday',
     },
     {
-      second: '0', minute: '0', hour: '8', day: '1', week: '*', day_of_week: '*', month: '*', year: '*', meaning: 'Run at 8:00 am (UTC+0) every 1st day of the month',
+      minute: '0', hour: '8', day: '1', week: '*', day_of_week: '*', month: '*', year: '*', meaning: 'Run at 8:00 am (UTC+0) every 1st day of the month',
     },
     {
-      second: '0', minute: '0/15', hour: '*', day: '*', week: '*', day_of_week: '*', month: '*', year: '*', meaning: 'Run every 15 minutes',
+      minute: '0/15', hour: '*', day: '*', week: '*', day_of_week: '*', month: '*', year: '*', meaning: 'Run every 15 minutes',
     },
     {
-      second: '0', minute: '0/10', hour: '*', day: '*', week: '*', day_of_week: 'MON-FRI', month: '*', year: '*', meaning: 'Run every 10 minutes Monday through Friday',
+      minute: '0/10', hour: '*', day: '*', week: '*', day_of_week: 'MON-FRI', month: '*', year: '*', meaning: 'Run every 10 minutes Monday through Friday',
     },
     {
-      second: '0', minute: '0/5', hour: '8-17', day: '*', week: '*', day_of_week: 'MON-FRI', month: '*', year: '*', meaning: 'Run every 5 minutes Monday through Friday between 8:00 am and 5:55 pm (UTC+0)',
+      minute: '0/5', hour: '8-17', day: '*', week: '*', day_of_week: 'MON-FRI', month: '*', year: '*', meaning: 'Run every 5 minutes Monday through Friday between 8:00 am and 5:55 pm (UTC+0)',
     },
   ];
 
@@ -216,6 +212,8 @@ function ScheduleModal({
                 label="Second"
                 tooltip="second (0-59)"
                 rules={[{ required: true, message: '' }]}
+                hidden
+                initialValue="0"
               >
                 <Input />
               </Form.Item>
@@ -301,6 +299,8 @@ function ScheduleModal({
               name={['trigger', 'seconds']}
               label="Seconds"
               tooltip="Number of seconds to wait"
+              hidden
+              initialValue="0"
             >
               <InputNumber />
             </Form.Item>

--- a/frontend/src/screens/dataset/index.jsx
+++ b/frontend/src/screens/dataset/index.jsx
@@ -535,6 +535,13 @@ const Dataset = withRouter(() => {
 
   const scheduleColumns = [
     {
+      title: 'NEXT RUN TIME',
+      dataIndex: 'next_run_time',
+      render: (text) => (
+        moment(text).local().format('ddd, D MMM YYYY HH:mm:ss Z')
+      ),
+    },
+    {
       title: 'SCHEDULE TYPE',
       dataIndex: 'trigger',
       render: (record) => (
@@ -552,13 +559,6 @@ const Dataset = withRouter(() => {
     {
       title: 'MAX INSTANCES',
       dataIndex: 'max_instances',
-    },
-    {
-      title: 'NEXT RUN TIME',
-      dataIndex: 'next_run_time',
-      render: (text) => (
-        moment(text).local().format('ddd, D MMM YYYY HH:mm:ss Z')
-      ),
     },
     {
       title: '',


### PR DESCRIPTION
# Description
To prevent scheduling issues, we have increased the minimum scheduling period from seconds to 1 minute.

We have also moved the "NEXT RUN TIME" to be the first column. 

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)


# Checklist:
- [x] I have performed a self-review of my own code
- [x] All GitHub workflows have passed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules