### PR TITLE
update requests to scheduler

### DIFF
--- a/backend/app/api/api_v1/endpoints/dataset.py
+++ b/backend/app/api/api_v1/endpoints/dataset.py
@@ -146,7 +146,7 @@ def delete_dataset(
     requests.delete(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules",
         params={"dataset_id": key},
-        headers=dict(mutable_headers),
+        headers=mutable_headers,
         cookies=request.cookies,
     )
 

--- a/backend/app/api/api_v1/endpoints/dataset.py
+++ b/backend/app/api/api_v1/endpoints/dataset.py
@@ -3,6 +3,7 @@ from typing import Optional, List
 from fastapi import APIRouter, HTTPException, status, Request
 from fastapi.params import Depends
 from fastapi.responses import JSONResponse
+from starlette.datastructures import MutableHeaders
 
 from app.api.shortcuts import delete_by_key_or_404, get_by_key_or_404
 from app.core.sample import GetSampleException, get_dataset_sample
@@ -138,11 +139,14 @@ def delete_dataset(
 
     validation_repository.delete_by_dataset(dataset_id=key)
 
+    # Convert the immutable headers to mutable headers
+    mutable_headers = MutableHeaders(request.headers)
+
     # TODO: use an internal function for this rather than making an HTTP request
     requests.delete(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules",
         params={"dataset_id": key},
-        headers=request.headers,
+        headers=dict(mutable_headers),
         cookies=request.cookies,
     )
 

--- a/backend/app/api/api_v1/endpoints/datasource.py
+++ b/backend/app/api/api_v1/endpoints/datasource.py
@@ -149,7 +149,7 @@ def delete_datasource(
     requests.delete(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules",
         params={"datasource_id": key},
-        headers=dict(mutable_headers),
+        headers=mutable_headers,
         cookies=request.cookies,
     )
 

--- a/backend/app/api/api_v1/endpoints/datasource.py
+++ b/backend/app/api/api_v1/endpoints/datasource.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Request
 from fastapi.responses import JSONResponse
 from opensearchpy import RequestError
 from sqlalchemy import create_engine
+from starlette.datastructures import MutableHeaders
 
 from app.api.shortcuts import get_by_key_or_404
 from app.core.users import current_active_user
@@ -142,10 +143,13 @@ def delete_datasource(
     dataset_repository.delete_by_datasource(key)
 
     # TODO: use an internal function for this rather than making an HTTP request
+    # Convert the immutable headers to mutable headers
+    mutable_headers = MutableHeaders(request.headers)
+
     requests.delete(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules",
         params={"datasource_id": key},
-        headers=request.headers,
+        headers=dict(mutable_headers),
         cookies=request.cookies,
     )
 

--- a/backend/app/api/api_v1/endpoints/schedule.py
+++ b/backend/app/api/api_v1/endpoints/schedule.py
@@ -4,6 +4,8 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.params import Depends
 from fastapi.responses import JSONResponse
 from fastapi import Request
+from starlette.datastructures import MutableHeaders
+
 from app.settings import settings
 from app.core.users import current_active_user
 from app.core.schedulers.scheduler import Schedule
@@ -35,6 +37,8 @@ def list_schedules(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="expected either 'dataset_id' or 'datasource_id'"
         )
+    # Convert the immutable headers to mutable headers
+    mutable_headers = MutableHeaders(request.headers)
 
     response = requests.get(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules",
@@ -42,7 +46,7 @@ def list_schedules(
             "dataset_id": dataset_id,
             "datasource_id": datasource_id
         },
-        headers=request.headers,
+        headers=dict(mutable_headers),
         cookies=request.cookies,
     )
     return JSONResponse(
@@ -58,11 +62,13 @@ def create_schedule(
         request: Request,
 ):
     payload = json.dumps(jsonable_encoder(schedule.dict(exclude_none=True)))
+    # Convert the immutable headers to mutable headers
+    mutable_headers = MutableHeaders(request.headers)
     response = requests.post(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules",
         params={"dataset_id": dataset_id},
         data=payload,
-        headers=request.headers,
+        headers=dict(mutable_headers),
         cookies=request.cookies,
     )
     return JSONResponse(
@@ -76,9 +82,11 @@ def get_schedule(
         schedule_id: str,
         request: Request,
 ):
+    # Convert the immutable headers to mutable headers
+    mutable_headers = MutableHeaders(request.headers)
     response = requests.get(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules/{schedule_id}",
-        headers=request.headers,
+        headers=dict(mutable_headers),
         cookies=request.cookies,
     )
     return JSONResponse(
@@ -94,10 +102,12 @@ def update_schedule(
         request: Request,
 ):
     payload = json.dumps(jsonable_encoder(schedule.dict(exclude_none=True)))
+    # Convert the immutable headers to mutable headers
+    mutable_headers = MutableHeaders(request.headers)
     response = requests.put(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules/{schedule_id}",
         data=payload,
-        headers=request.headers,
+        headers=dict(mutable_headers),
         cookies=request.cookies,
     )
     return JSONResponse(
@@ -111,9 +121,11 @@ def delete_schedule(
         schedule_id: str,
         request: Request,
 ):
+    # Convert the immutable headers to mutable headers
+    mutable_headers = MutableHeaders(request.headers)
     response = requests.delete(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules/{schedule_id}",
-        headers=request.headers,
+        headers=dict(mutable_headers),
         cookies=request.cookies,
     )
     return JSONResponse(
@@ -142,18 +154,21 @@ def delete_schedules(
 
     response = None
 
+    # Convert the immutable headers to mutable headers
+    mutable_headers = MutableHeaders(request.headers)
+
     if dataset_id:
         response = requests.delete(
             url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules",
             params={"dataset_id": dataset_id},
-            headers=request.headers,
+            headers=dict(mutable_headers),
             cookies=request.cookies,
         )
     elif datasource_id:
         response = requests.delete(
             url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules",
             params={"datasource_id": datasource_id},
-            headers=request.headers,
+            headers=dict(mutable_headers),
             cookies=request.cookies,
         )
 
@@ -169,10 +184,12 @@ def next_schedule_run_times(
         request: Request,
 ):
     payload = json.dumps(jsonable_encoder(schedule.dict(exclude_none=True)))
+    # Convert the immutable headers to mutable headers
+    mutable_headers = MutableHeaders(request.headers)
     response = requests.post(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules/next-run-times",
         data=payload,
-        headers=request.headers,
+        headers=dict(mutable_headers),
         cookies=request.cookies,
     )
     return JSONResponse(

--- a/backend/app/api/api_v1/endpoints/schedule.py
+++ b/backend/app/api/api_v1/endpoints/schedule.py
@@ -46,7 +46,7 @@ def list_schedules(
             "dataset_id": dataset_id,
             "datasource_id": datasource_id
         },
-        headers=dict(mutable_headers),
+        headers=mutable_headers,
         cookies=request.cookies,
     )
     return JSONResponse(
@@ -68,7 +68,7 @@ def create_schedule(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules",
         params={"dataset_id": dataset_id},
         data=payload,
-        headers=dict(mutable_headers),
+        headers=mutable_headers,
         cookies=request.cookies,
     )
     return JSONResponse(
@@ -86,7 +86,7 @@ def get_schedule(
     mutable_headers = MutableHeaders(request.headers)
     response = requests.get(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules/{schedule_id}",
-        headers=dict(mutable_headers),
+        headers=mutable_headers,
         cookies=request.cookies,
     )
     return JSONResponse(
@@ -107,7 +107,7 @@ def update_schedule(
     response = requests.put(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules/{schedule_id}",
         data=payload,
-        headers=dict(mutable_headers),
+        headers=mutable_headers,
         cookies=request.cookies,
     )
     return JSONResponse(
@@ -125,7 +125,7 @@ def delete_schedule(
     mutable_headers = MutableHeaders(request.headers)
     response = requests.delete(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules/{schedule_id}",
-        headers=dict(mutable_headers),
+        headers=mutable_headers,
         cookies=request.cookies,
     )
     return JSONResponse(
@@ -161,14 +161,14 @@ def delete_schedules(
         response = requests.delete(
             url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules",
             params={"dataset_id": dataset_id},
-            headers=dict(mutable_headers),
+            headers=mutable_headers,
             cookies=request.cookies,
         )
     elif datasource_id:
         response = requests.delete(
             url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules",
             params={"datasource_id": datasource_id},
-            headers=dict(mutable_headers),
+            headers=mutable_headers,
             cookies=request.cookies,
         )
 
@@ -189,7 +189,7 @@ def next_schedule_run_times(
     response = requests.post(
         url=f"{settings.SCHEDULER_API_URL}/api/v1/schedules/next-run-times",
         data=payload,
-        headers=dict(mutable_headers),
+        headers=mutable_headers,
         cookies=request.cookies,
     )
     return JSONResponse(


### PR DESCRIPTION
# Description
When adding distributed tracing such as open telemetry, it requires the ability to modify headers. This PR allows that for requests between swiple-api and swiple-scheduler

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] All GitHub workflows have passed
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules