### PR TITLE
Forbid delete or update of admin user

### DIFF
--- a/backend/app/models/users.py
+++ b/backend/app/models/users.py
@@ -2,7 +2,15 @@ from fastapi_users import models
 
 
 class User(models.BaseUser):
-    pass
+    is_admin_user: bool = False
+
+
+class AdminUserCreate(models.BaseUserCreate):
+    is_admin_user: bool = False
+
+
+class AdminUserUpdate(models.BaseUserUpdate):
+    is_admin_user: bool = False
 
 
 class UserCreate(models.BaseUserCreate):
@@ -14,4 +22,4 @@ class UserUpdate(models.BaseUserUpdate):
 
 
 class UserDB(User, models.BaseUserDB):
-    pass
+    is_admin_user: bool = False

--- a/backend/app/scripts/create_admin_user.py
+++ b/backend/app/scripts/create_admin_user.py
@@ -2,7 +2,7 @@ import fastapi_users.manager
 
 from app.settings import settings
 from app.core.users import get_user_db, get_user_manager
-from app.models.users import UserUpdate, UserCreate
+from app.models.users import AdminUserCreate, AdminUserUpdate
 import asyncio
 
 
@@ -13,26 +13,29 @@ async def create_admin_user():
         user = await user_manager.get_by_email(settings.ADMIN_EMAIL)
 
         print("Admin user already exists. Updating...")
-        user_update = UserUpdate(
+        user_update = AdminUserUpdate(
             email=settings.ADMIN_EMAIL,
             password=settings.ADMIN_PASSWORD,
             is_superuser=True,
             is_active=True,
+            is_admin_user=True,
         )
         await user_manager.update(
             user_update=user_update,
             user=user,
+            allow_admin_update=True,
         )
         print("Admin user updated.")
     except fastapi_users.manager.UserNotExists:
         print("Creating admin user.")
         # Create admin user
         await user_manager.create(
-            UserCreate(
+            AdminUserCreate(
                 email=settings.ADMIN_EMAIL,
                 password=settings.ADMIN_PASSWORD,
                 is_superuser=True,
                 is_verified=True,
+                is_admin_user=True,
             )
         )
         print("Admin user created")

--- a/frontend/src/screens/settingsOverview/components/UserOverview.jsx
+++ b/frontend/src/screens/settingsOverview/components/UserOverview.jsx
@@ -98,7 +98,7 @@ export default function userOverview() {
     {
       title: 'Email',
       dataIndex: 'email',
-      render: (text) => (
+      render: (text, record) => (
         <Row>
           <Space>
             <Text>{text}</Text>
@@ -110,6 +110,18 @@ export default function userOverview() {
                   }}
                   >
                     You
+                  </Tag>
+                )
+                : null
+            }
+            {
+              record.is_admin_user
+                ? (
+                  <Tag style={{
+                    border: 0, fontWeight: 'bold',
+                  }}
+                  >
+                    Admin user
                   </Tag>
                 )
                 : null
@@ -136,17 +148,23 @@ export default function userOverview() {
     {
       title: '',
       render: (text, record) => (
-        <Dropdown
-          trigger={['click']}
-          overlay={userMenu(record)}
-          placement="bottomRight"
-          arrow
-        >
-          <Button
-            type="text"
-            icon={<EllipsisOutlined rotate={90} style={{ fontWeight: 'bold', fontSize: '25px' }} />}
-          />
-        </Dropdown>
+        <div>
+          {
+            record.is_admin_user !== true ? (
+              <Dropdown
+                trigger={['click']}
+                overlay={userMenu(record)}
+                placement="bottomRight"
+                arrow
+              >
+                <Button
+                  type="text"
+                  icon={<EllipsisOutlined rotate={90} style={{ fontWeight: 'bold', fontSize: '25px' }} />}
+                />
+              </Dropdown>
+            ) : null
+          }
+        </div>
       ),
     },
   ];


### PR DESCRIPTION
# Description
In this PR we introduce logic in the UserManager to forbid the Admin User from being updated or deleted via the API. The admin user can still be modified internally which occurs in the `setup` container.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] All GitHub workflows have passed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules