### PR TITLE
remove dependency on rabbitmq

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -83,7 +83,7 @@ class Settings(BaseSettings):
     CELERY_INDEX: str = "celery"
 
     SWIPLE_CELERY_CONFIG: dict = {
-        "broker_url": "pyamqp://localhost:5672",
+        "broker_url": "redis://redis:6379/1",
         "result_backend": "app.worker.backends.opensearch.OpenSearchBackend://_:_@_:9200/celery",
         "task_default_queue": "swiple-job-queue",
         "task_soft_time_limit": "5400",  # SOFT LIMIT: 90 minutes

--- a/docker-compose-non-dev.yaml
+++ b/docker-compose-non-dev.yaml
@@ -54,12 +54,6 @@ services:
     depends_on:
       - "swiple_api"
 
-  rabbit:
-    image: rabbitmq:3.9
-    ports:
-      - 5672:5672
-      - 15672:15672
-
   celery_worker:
     container_name: celery_worker
     env_file: docker/.env
@@ -71,7 +65,6 @@ services:
     environment:
       <<: *aws-creds
     depends_on:
-      - rabbit
       - swiple_api
 
   setup:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -73,12 +73,6 @@ services:
     volumes:
       - ./backend/app/sample_data/:/code/app/sample_data/
 
-  rabbit:
-    image: rabbitmq:3.9
-    ports:
-      - 5672:5672
-      - 15672:15672
-
   celery_worker:
     container_name: celery_worker
     env_file: docker/.env
@@ -90,7 +84,6 @@ services:
     environment:
       <<: *aws-creds
     depends_on:
-      - rabbit
       - swiple_api
 
   postgres:

--- a/docker/.env
+++ b/docker/.env
@@ -4,4 +4,3 @@ ADMIN_EMAIL=admin@email.com
 ADMIN_PASSWORD=AdminUser12!
 SECRET_KEY=jSE9Q7_5g1MDpCz7wU1xmcmz27RhSo8nRXCPRjjE6dg=
 AUTH_COOKIE_SECURE=False
-SWIPLE_CELERY_CONFIG='{"broker_url": "pyamqp://rabbit:5672", "result_backend": "app.worker.backends.opensearch.OpenSearchBackend://_:_@_:9200/celery", "task_default_queue": "swiple-job-queue", "task_soft_time_limit": "5400", "task_time_limit": "5700", "worker_prefetch_multiplier": "1"}'

--- a/docker/.env-local
+++ b/docker/.env-local
@@ -12,3 +12,5 @@ ADMIN_EMAIL=admin@email.com
 ADMIN_PASSWORD=AdminUser12!
 SECRET_KEY=jSE9Q7_5g1MDpCz7wU1xmcmz27RhSo8nRXCPRjjE6dg=
 AUTH_COOKIE_SECURE=False
+
+SWIPLE_CELERY_CONFIG='{"broker_url": "redis://localhost:6379/1", "result_backend": "app.worker.backends.opensearch.OpenSearchBackend://_:_@_:9200/celery", "task_default_queue": "swiple-job-queue", "task_soft_time_limit": "5400", "task_time_limit": "5700", "worker_prefetch_multiplier": "1"}'


### PR DESCRIPTION
# Description
In this PR we switch the default Celery broker from RabbitMQ to Redis, removing our dependency on RabbitMQ and reducing the number of technologies we depend on.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] All GitHub workflows have passed
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules