### PR TITLE
Fix docker-compose-non-dev.yaml

### DIFF
--- a/docker-compose-non-dev.yaml
+++ b/docker-compose-non-dev.yaml
@@ -58,7 +58,7 @@ services:
     container_name: celery_worker
     env_file: docker/.env
     command: celery --app=app.worker.app.celery_app worker -l info -c 4 -Ofair --without-heartbeat --without-gossip --without-mingle --loglevel=warning
-    image: swiple-api:latest
+    image: swiple/swiple-api:latest
     volumes:
       - $PWD/backend/app/:/code/app/
       - $HOME/.aws:$HOME/.aws


### PR DESCRIPTION
# Description
Fix path to swiple-api container in docker-compose-non-dev.yaml.

Fixes # (issue)
 path to swiple-api container in docker-compose-non-dev.yaml.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] All GitHub workflows have passed
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules